### PR TITLE
Update window and pane title on buffer change (resolves #53).

### DIFF
--- a/emamux.el
+++ b/emamux.el
@@ -40,6 +40,8 @@
 (require 'cl-lib)
 (require 'tramp)
 
+(with-eval-after-load "emamux" (emamux:setup-hooks))
+
 (defgroup emamux nil
   "tmux manipulation from Emacs"
   :prefix "emamux:"
@@ -554,6 +556,17 @@ With prefix-arg, use '-a' option to insert the new window next to current index.
   (let ((input (buffer-substring-no-properties beg end)))
     (emamux:run-command input)))
 
+(defun emamux:set-title-string (title)
+  (emamux:tmux-run-command nil "rename-window" title)
+  (emamux:tmux-run-command nil "select-pane" "-T" title))
+
+(defun emamux-hook-buffer-change (frame)
+  (if (buffer-name)
+    (emamux:set-title-string (buffer-name))))
+
+(defun emamux:setup-hooks ()
+  (add-hook 'window-buffer-change-functions 'emamux-hook-buffer-change)
+  (add-hook 'window-selection-change-functions 'emamux-hook-buffer-change))
 
 (defvar emamux:keymap
   (let ((map (make-sparse-keymap)))


### PR DESCRIPTION
When using Tmux, I find window titles very useful to quickly jump to the right window. I even set titles from within some scripts to something meaningful.
So, when running Emacs on several windows, it helps me a lot to see the opened buffer instead of 'emacsclient' in their titles, to locate them quickly.

Although my use-case does not involve panes, I'm also updating pane title, for those who like to work with them. You can have a window with 2 panes and pane titles display opened buffer (you have to enable pane status).

Also, I've added an utility function to set window and pane titles to whatever string you want.