### PR TITLE
Consider emamux:session when listing windows

### DIFF
--- a/emamux.el
+++ b/emamux.el
@@ -501,7 +501,7 @@ With prefix-arg, use '-a' option to insert the new window next to current index.
 
 (defun emamux:list-windows ()
   (with-temp-buffer
-    (emamux:tmux-run-command t "list-windows")
+    (emamux:tmux-run-command t "list-windows" "-t" emamux:session)
     (cl-loop initially (goto-char (point-min))
              while (re-search-forward "^\\(.+\\)$" nil t)
              collect (match-string-no-properties 1))))


### PR DESCRIPTION
See #51

Thanks to this I can do for example:

    (let ((emamux:session "my-session-name"))
      (emamux:list-windows))